### PR TITLE
Let flake8 handle errors squleched by noqa

### DIFF
--- a/flake8_new_union_types.py
+++ b/flake8_new_union_types.py
@@ -95,9 +95,6 @@ class PEP604Checker:
         visitor = self.visitor(filename=self.filename, lines=self.lines)
         visitor.visit(self.tree)
         for e in visitor.errors:
-            if pycodestyle.noqa(self.lines[e.lineno - 1]):
-                continue
-
             yield self.adapt_error(e)
 
     @classmethod


### PR DESCRIPTION
This makes flake8-new-union-types compatible with [flake8-noqa](https://github.com/plinss/flake8-noqa). Currently, flake8-new-union-types handles any `noqa` marks itself rather than letting flake8 itself handle it. `flake8-noqa` says this is "considered an anti-pattern". By removing the code that ignores `noqa` comments, flake8 still squelches marked errors appropriately, but the `flake8-noqa` plugin can see them so that it does not think the `noqa` comment is squelching nothing.